### PR TITLE
Add correct console plugin image for <= OCP 4.17 to configmap

### DIFF
--- a/downstream-conversion/bundle/manifests/kuadrant-operator-console-plugin-images_v1_configmap.yaml
+++ b/downstream-conversion/bundle/manifests/kuadrant-operator-console-plugin-images_v1_configmap.yaml
@@ -2,8 +2,8 @@
 
 apiVersion: v1
 data:
-  "4.16": quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-2-rhcl-console-plugin@sha256:7ef82af7bd9b466e0d452137a2dbcdb81446d82ea8e3b0c5cf144d0acd2d4c6e
-  "4.17": quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-2-rhcl-console-plugin@sha256:7ef82af7bd9b466e0d452137a2dbcdb81446d82ea8e3b0c5cf144d0acd2d4c6e
+  "4.16": registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:ae92d638d993d782986e761d5aa3c7c5da2b8af0aabc1decb332a4f1487dacd3
+  "4.17": registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:ae92d638d993d782986e761d5aa3c7c5da2b8af0aabc1decb332a4f1487dacd3
   "4.18": quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-2-rhcl-console-plugin@sha256:7ef82af7bd9b466e0d452137a2dbcdb81446d82ea8e3b0c5cf144d0acd2d4c6e
   "4.19": quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-2-rhcl-console-plugin@sha256:7ef82af7bd9b466e0d452137a2dbcdb81446d82ea8e3b0c5cf144d0acd2d4c6e
   "4.20": quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-2-rhcl-console-plugin@sha256:7ef82af7bd9b466e0d452137a2dbcdb81446d82ea8e3b0c5cf144d0acd2d4c6e


### PR DESCRIPTION
@eguzki FYI (can update the image here to the one we release for 1.1.1 if needed, this is just to enable QE to test 1.2.0 RC1 ASAP)