### PR TITLE
Add new gh action to automate running of pipeline-patcher script

### DIFF
--- a/.github/workflows/update-pipelines.yml
+++ b/.github/workflows/update-pipelines.yml
@@ -1,0 +1,156 @@
+# GitHub Action to automatically update Konflux pipeline task references to their latest versions
+# This workflow uses konflux-pipeline-patcher to bump task references in Tekton pipeline files
+# Note: The pipeline-patcher 'bump-task-refs' command runs on all pipelines, but we can
+# selectively commit only the files specified by the user
+name: Update Pipeline Task References
+
+on:
+  # Manual trigger only - run via GitHub UI or gh CLI
+  workflow_dispatch:
+    inputs:
+      pipeline_name:
+        description: 'Pipeline to update'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - all  # Commit updates to all pipeline files in .tekton/
+          - bundle-build-pipeline.yaml
+          - multi-arch-build-pipeline.yaml
+
+# Required permissions for creating commits and pull requests
+permissions:
+  contents: write        # Needed to commit changes
+  pull-requests: write   # Needed to create PRs
+
+jobs:
+  update-pipelines:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Checkout the repository with submodules
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive  # Include kuadrant-operator submodule
+
+      # Step 2: Run konflux-pipeline-patcher to update task references
+      # The pipeline-patcher script analyzes Tekton pipeline files and updates
+      # task references (e.g., git-clone, buildah) to their latest available versions
+      # Note: The tool always updates ALL pipelines; we filter which ones to commit in the next step
+      - name: Update pipeline task references
+        id: update
+        run: |
+          cd .tekton
+
+          # The 'bump-task-refs' command updates task bundle references to latest versions
+          # It operates on the entire directory (no option to target a single file)
+          echo "Running pipeline-patcher on all pipelines in .tekton/"
+          curl -sL https://github.com/simonbaird/konflux-pipeline-patcher/raw/main/pipeline-patcher | bash -s bump-task-refs .
+
+      # Step 3: Filter changes based on user selection and check if there are updates to commit
+      # If a specific pipeline was selected, discard changes to other files
+      - name: Check for changes
+        id: check
+        run: |
+          if [ "${{ inputs.pipeline_name }}" != "all" ]; then
+            # Only keep changes to the selected pipeline file
+            SELECTED_FILE=".tekton/${{ inputs.pipeline_name }}"
+
+            # Verify the file exists
+            if [ ! -f "$SELECTED_FILE" ]; then
+              echo "Error: Pipeline file '$SELECTED_FILE' not found"
+              exit 1
+            fi
+
+            echo "Filtering to only keep changes in $SELECTED_FILE"
+
+            # Get list of all changed files in .tekton/ except the selected one
+            # and restore them to discard the changes
+            git diff --name-only .tekton/ | while read -r file; do
+              if [ "$file" != "$SELECTED_FILE" ]; then
+                echo "  Discarding changes in $file"
+                git restore "$file"
+              fi
+            done
+
+            # Now check if the selected file has changes
+            if git diff --quiet "$SELECTED_FILE"; then
+              echo "changes=false" >> $GITHUB_OUTPUT
+              echo "No changes detected in $SELECTED_FILE"
+            else
+              echo "changes=true" >> $GITHUB_OUTPUT
+              echo "Changes detected in $SELECTED_FILE:"
+              git diff --stat "$SELECTED_FILE"
+            fi
+          else
+            # Check if any pipeline files changed
+            if git diff --quiet .tekton/; then
+              echo "changes=false" >> $GITHUB_OUTPUT
+              echo "No changes detected"
+            else
+              echo "changes=true" >> $GITHUB_OUTPUT
+              echo "Changes detected:"
+              git diff --stat .tekton/
+            fi
+          fi
+
+      # Step 4: Create a pull request with the updated pipeline files
+      # This step only runs if changes were detected in the previous step
+      - name: Create Pull Request
+        if: steps.check.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Commit message for the changes
+          commit-message: |
+            Update Konflux pipeline task references
+
+            ${{ inputs.pipeline_name == 'all' && 'Updated all pipelines' || format('Updated pipeline: {0}', inputs.pipeline_name) }}
+
+            Automated update using konflux-pipeline-patcher to bump task references to latest versions.
+          # Use run number to ensure unique branch names for each workflow run
+          branch: update-pipeline-tasks-${{ github.run_number }}
+          delete-branch: true  # Clean up the branch after PR is merged/closed
+          # PR title indicates which pipeline(s) were updated
+          title: |
+            Update Konflux pipeline task references${{ inputs.pipeline_name != 'all' && format(' ({0})', inputs.pipeline_name) || '' }}
+          # PR body with details about what was updated
+          body: |
+            ## Pipeline Task Reference Updates
+
+            ${{ inputs.pipeline_name == 'all' && 'This PR updates the task references for all pipelines in `.tekton/`.' || format('This PR updates the task references for the **{0}** pipeline.', inputs.pipeline_name) }}
+
+            ### Changes
+
+            The following task references have been updated to their latest versions using [konflux-pipeline-patcher](https://github.com/simonbaird/konflux-pipeline-patcher):
+
+            ```
+            ${{ steps.update.outputs.summary }}
+            ```
+
+            ### Testing
+
+            - [ ] Review the updated task references
+            - [ ] Verify pipeline configurations are correct
+            - [ ] Test pipeline execution if needed
+
+            ---
+
+            *This PR was automatically created by the [update-pipelines workflow](.github/workflows/update-pipelines.yml).*
+          # Add labels to help categorize the PR
+          labels: |
+            automated
+            tekton
+            pipeline-update
+          # Assign the person who triggered the workflow as a reviewer
+          reviewers: |
+            ${{ github.actor }}
+
+      # Step 5: Print a summary of what happened
+      - name: Summary
+        run: |
+          if [ "${{ steps.check.outputs.changes }}" == "true" ]; then
+            echo "✅ Pipeline task references updated and PR created"
+          else
+            echo "ℹ️ No updates needed - all task references are current"
+          fi


### PR DESCRIPTION
We are going to be required to have a review on all PRs from end of March, automating the script at curl -sL https://github.com/simonbaird/konflux-pipeline-patcher/raw/main/pipeline-patcher | bash -s bump-task-refs

Will make it so we can still bump these tasks, but with approval (from the runner of the gh action)

Closes #279 