### PR TITLE
Fix git index.lock error in pipeline update workflow

### DIFF
--- a/.github/scripts/update-pipeline-tasks.sh
+++ b/.github/scripts/update-pipeline-tasks.sh
@@ -114,12 +114,22 @@ filter_changes() {
     local selected_file="$TEKTON_DIR/$PIPELINE_NAME"
 
     # Get list of changed files in .tekton/ and restore all except the selected one
-    git diff --name-only "$TEKTON_DIR/" 2>/dev/null | while IFS= read -r file; do
+    # Store files in an array to avoid issues with piped while loops
+    local files_to_restore=()
+    while IFS= read -r file; do
         if [ "$file" != "$selected_file" ]; then
-            info "  Discarding changes in $file"
-            git restore "$file"
+            files_to_restore+=("$file")
         fi
+    done < <(git diff --name-only "$TEKTON_DIR/" 2>/dev/null)
+
+    # Restore files outside of the while loop
+    for file in "${files_to_restore[@]}"; do
+        info "  Discarding changes in $file"
+        git restore "$file" || warn "Failed to restore $file (may have been deleted)"
     done
+
+    # Ensure all git operations are complete
+    sync
 }
 
 # Check if there are changes to commit
@@ -174,6 +184,8 @@ main() {
             info "Changes ready to commit"
             info "Run 'git diff $TEKTON_DIR/' to review changes"
         fi
+        # Ensure all git operations are complete before exiting
+        sync
         # Set GitHub Actions output if running in CI
         if [ -n "$GITHUB_OUTPUT" ]; then
             echo "changes=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-pipelines.yml
+++ b/.github/workflows/update-pipelines.yml
@@ -55,7 +55,17 @@ jobs:
           chmod +x .github/scripts/update-pipeline-tasks.sh
           .github/scripts/update-pipeline-tasks.sh "${{ inputs.pipeline_name }}"
 
-      # Step 4: Create a pull request with the updated pipeline files
+      # Step 4: Clean up any stale git locks before creating PR
+      # Ensures no lock files from previous git operations interfere
+      - name: Clean up git locks
+        if: steps.update.outputs.changes == 'true'
+        run: |
+          # Remove stale git lock files if they exist
+          rm -f .git/index.lock
+          rm -f .git/refs/heads/*.lock
+          rm -f .git/refs/remotes/*/*.lock
+
+      # Step 5: Create a pull request with the updated pipeline files
       # This step only runs if changes were detected by the update script
       - name: Create Pull Request
         if: steps.update.outputs.changes == 'true'
@@ -107,7 +117,7 @@ jobs:
           reviewers: |
             ${{ github.actor }}
 
-      # Step 5: Print a summary of what happened
+      # Step 6: Print a summary of what happened
       - name: Summary
         run: |
           if [ "${{ steps.update.outputs.changes }}" == "true" ]; then


### PR DESCRIPTION
Resolves concurrent git operations causing lock file conflicts between the update script and create-pull-request action. Added cleanup step to remove stale locks and improved script to ensure git operations complete before exiting.