### PR TITLE
Only commit .tekton/ files in pipeline update workflow

### DIFF
--- a/.github/workflows/update-pipelines.yml
+++ b/.github/workflows/update-pipelines.yml
@@ -72,6 +72,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          add: '.tekton/'  # Only stage pipeline files, ignore ORAS artifacts
           # Commit message for the changes
           commit-message: |
             Update Konflux pipeline task references


### PR DESCRIPTION
Add explicit 'add' parameter to create-pull-request action to stage only .tekton/ directory files. This prevents ORAS installation artifacts (LICENSE, README) from being included in the automated PR.