### PR TITLE
task(issue-24): update kuadrant-operator to track release-v1.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "kuadrant-operator"]
 	path = kuadrant-operator
 	url = https://github.com/kuadrant/kuadrant-operator
-	branch = release-v1.3
+	branch = release-v1.4


### PR DESCRIPTION
Update the kuadrant-operator submodule configuration to track the release-v1.4 branch instead of release-v1.3.

Part of the downstream submodule alignment effort.
Related: Kuadrant/sector#24