### PR TITLE
Changes for RHCL 1.3.3

### DIFF
--- a/Containerfile.rhcl-operator-bundle
+++ b/Containerfile.rhcl-operator-bundle
@@ -17,7 +17,7 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 
-LABEL version="1.3.2" \
+LABEL version="1.3.3" \
       summary="Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments" \
       name="rhcl-1/rhcl-operator-bundle" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \
@@ -28,7 +28,7 @@ LABEL version="1.3.2" \
       io.openshift.tags="api" \
       url="redhat.com" \
       distribution-scope="public" \
-      release="1.3.1" \
+      release="1.3.3" \
       url="" \
       com.redhat.component="Red Hat Connectivity Link Operator Bundle" \
       vendor="Red Hat, Inc."

--- a/Containerfile.rhcl-operator-bundle-dev
+++ b/Containerfile.rhcl-operator-bundle-dev
@@ -17,7 +17,7 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 
-LABEL version="1.3.2" \
+LABEL version="1.3.3" \
       summary="Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments" \
       name="rhcl-1/rhcl-operator-bundle" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \
@@ -28,7 +28,7 @@ LABEL version="1.3.2" \
       io.openshift.tags="api" \
       url="redhat.com" \
       distribution-scope="public" \
-      release="1.3.1" \
+      release="1.3.3" \
       url="" \
       com.redhat.component="Red Hat Connectivity Link Operator Bundle" \
       vendor="Red Hat, Inc."

--- a/Containerfile.rhcl-operator-bundle-stage
+++ b/Containerfile.rhcl-operator-bundle-stage
@@ -17,7 +17,7 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 
-LABEL version="1.3.2" \
+LABEL version="1.3.3" \
       summary="Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments" \
       name="rhcl-1/rhcl-operator-bundle" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \
@@ -28,7 +28,7 @@ LABEL version="1.3.2" \
       io.openshift.tags="api" \
       url="redhat.com" \
       distribution-scope="public" \
-      release="1.3.1" \
+      release="1.3.3" \
       url="" \
       com.redhat.component="Red Hat Connectivity Link Operator Bundle" \
       vendor="Red Hat, Inc."

--- a/bundle-dev/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle-dev/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -242,7 +242,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-  name: rhcl-operator.v1.3.2
+  name: rhcl-operator.v1.3.3
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -918,4 +918,4 @@ spec:
       name: console-plugin-latest
     - image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-rhcl-console-plugin-0-1-5@sha256:c72f23284033de1032e2b209cd2c6087ad0f1aacb8c7312fd324df3d8fee49b9
       name: console-plugin-pf5
-  version: 1.3.2
+  version: 1.3.3

--- a/bundle-generation/rhcl-operator.yaml
+++ b/bundle-generation/rhcl-operator.yaml
@@ -4,8 +4,8 @@
 
 # CSV metadata
 csv:
-  name: rhcl-operator.v1.3.2
-  version: "1.3.2"
+  name: rhcl-operator.v1.3.3
+  version: "1.3.3"
   displayName: Red Hat Connectivity Link
   description: "Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments."
   icon:

--- a/bundle-stage/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle-stage/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -242,7 +242,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-  name: rhcl-operator.v1.3.2
+  name: rhcl-operator.v1.3.3
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -918,4 +918,4 @@ spec:
       name: console-plugin-latest
     - image: registry.stage.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:c72f23284033de1032e2b209cd2c6087ad0f1aacb8c7312fd324df3d8fee49b9
       name: console-plugin-pf5
-  version: 1.3.2
+  version: 1.3.3

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -242,7 +242,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-  name: rhcl-operator.v1.3.2
+  name: rhcl-operator.v1.3.3
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -918,4 +918,4 @@ spec:
       name: console-plugin-latest
     - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:c72f23284033de1032e2b209cd2c6087ad0f1aacb8c7312fd324df3d8fee49b9
       name: console-plugin-pf5
-  version: 1.3.2
+  version: 1.3.3


### PR DESCRIPTION
This will be more or less an "empty" release with no real changes, its main purpose is to enable docs to be published around the TP of MCP Gateway, with this in mind, a new bundle is all we need to ship.