### PR TITLE
Patch release action

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -9,10 +9,10 @@ Automates version bumping for RHCL releases.
 ### Usage
 
 ```bash
-# Basic usage - bumps both RHCL and Kuadrant to the same version
+# Update only RHCL version (leaves Kuadrant version unchanged)
 ./bump-version.sh 1.3.4
 
-# Specify different Kuadrant version
+# Update both RHCL and Kuadrant versions
 ./bump-version.sh 1.3.4 1.4.0
 ```
 
@@ -36,8 +36,11 @@ Automates version bumping for RHCL releases.
 ```bash
 cd /path/to/rhcl-operator-product-build
 
-# Bump to 1.3.4 (both RHCL and Kuadrant)
+# Bump only RHCL version to 1.3.4 (leaves Kuadrant unchanged)
 .github/scripts/bump-version.sh 1.3.4
+
+# Or bump both RHCL and Kuadrant versions
+.github/scripts/bump-version.sh 1.3.4 1.4.0
 
 # Review changes
 git diff

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,54 @@
+# Scripts
+
+This directory contains utility scripts for maintaining the RHCL operator build infrastructure.
+
+## bump-version.sh
+
+Automates version bumping for RHCL releases.
+
+### Usage
+
+```bash
+# Basic usage - bumps both RHCL and Kuadrant to the same version
+./bump-version.sh 1.3.4
+
+# Specify different Kuadrant version
+./bump-version.sh 1.3.4 1.4.0
+```
+
+### What it does
+
+1. **Updates RHCL version** in:
+   - `Containerfile.rhcl-operator` (release label, if present)
+   - `Containerfile.rhcl-operator-bundle` (version + release labels)
+   - `Containerfile.rhcl-operator-bundle-dev` (version + release labels)
+   - `Containerfile.rhcl-operator-bundle-stage` (version + release labels)
+   - `bundle-generation/rhcl-operator.yaml` (CSV name + version)
+
+2. **Updates Kuadrant version** in:
+   - `.tekton/rhcl-*-rhcl-operator-push.yaml` (KUADRANT_VERSION build arg)
+   - `.tekton/rhcl-*-rhcl-operator-pull-request.yaml` (KUADRANT_VERSION build arg)
+   
+   _Note: The script automatically detects the correct pipeline files for the current branch (e.g., `rhcl-1-2-`, `rhcl-1-3-`, etc.)._
+
+### Running locally
+
+```bash
+cd /path/to/rhcl-operator-product-build
+
+# Bump to 1.3.4 (both RHCL and Kuadrant)
+.github/scripts/bump-version.sh 1.3.4
+
+# Review changes
+git diff
+
+# Commit and create PR
+git checkout -b prep-1.3.4
+git commit -am "Prepare RHCL 1.3.4 release"
+git push -u origin prep-1.3.4
+gh pr create --title "Prepare RHCL 1.3.4 release"
+```
+
+## update-pipeline-tasks.sh
+
+Updates Konflux pipeline task references to their latest versions. See [update-pipelines workflow](../workflows/update-pipelines.yml).

--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -7,7 +7,7 @@ set -e
 #   kuadrant-version: Optional. Upstream Kuadrant version (e.g., 0.10.0). Defaults to rhcl-version if not provided.
 
 RHCL_VERSION="$1"
-KUADRANT_VERSION="${2:-$1}"  # Default to RHCL version if not provided
+KUADRANT_VERSION="$2"  # Optional - leave unchanged if not provided
 
 # Validation
 if [ -z "$RHCL_VERSION" ]; then
@@ -21,9 +21,11 @@ if ! echo "$RHCL_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   exit 1
 fi
 
-if ! echo "$KUADRANT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-  echo "Error: Kuadrant version must be in X.Y.Z format (e.g., 0.10.0)"
-  exit 1
+if [ -n "$KUADRANT_VERSION" ]; then
+  if ! echo "$KUADRANT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "Error: Kuadrant version must be in X.Y.Z format (e.g., 0.10.0)"
+    exit 1
+  fi
 fi
 
 # Detect current RHCL version from bundle-generation/rhcl-operator.yaml
@@ -39,7 +41,11 @@ echo "RHCL Version Bump"
 echo "========================================"
 echo "Current RHCL version: $CURRENT_RHCL_VERSION"
 echo "New RHCL version: $RHCL_VERSION"
-echo "Kuadrant version: $KUADRANT_VERSION"
+if [ -n "$KUADRANT_VERSION" ]; then
+  echo "Kuadrant version: $KUADRANT_VERSION"
+else
+  echo "Kuadrant version: (unchanged)"
+fi
 echo "========================================"
 echo ""
 
@@ -70,41 +76,46 @@ sed -i "s/rhcl-operator\.v$CURRENT_RHCL_VERSION/rhcl-operator.v$RHCL_VERSION/g" 
 sed -i "s/version: \"$CURRENT_RHCL_VERSION\"/version: \"$RHCL_VERSION\"/g" bundle-generation/rhcl-operator.yaml
 echo ""
 
-# Step 4: Update KUADRANT_VERSION in Tekton pipelines
-echo "Updating Tekton pipelines..."
+# Step 4: Update KUADRANT_VERSION in Tekton pipelines (if provided)
+if [ -n "$KUADRANT_VERSION" ]; then
+  echo "Updating Tekton pipelines..."
 
-# Find the operator pipeline files (branch-agnostic)
-PUSH_PIPELINE=$(find .tekton -name 'rhcl-*-rhcl-operator-push.yaml' | head -n1)
-PR_PIPELINE=$(find .tekton -name 'rhcl-*-rhcl-operator-pull-request.yaml' | head -n1)
+  # Find the operator pipeline files (branch-agnostic)
+  PUSH_PIPELINE=$(find .tekton -name 'rhcl-*-rhcl-operator-push.yaml' | head -n1)
+  PR_PIPELINE=$(find .tekton -name 'rhcl-*-rhcl-operator-pull-request.yaml' | head -n1)
 
-if [ -z "$PUSH_PIPELINE" ] || [ -z "$PR_PIPELINE" ]; then
-  echo "Error: Could not find operator pipeline files in .tekton/"
-  echo "Expected files matching: rhcl-*-rhcl-operator-push.yaml and rhcl-*-rhcl-operator-pull-request.yaml"
-  exit 1
-fi
+  if [ -z "$PUSH_PIPELINE" ] || [ -z "$PR_PIPELINE" ]; then
+    echo "Error: Could not find operator pipeline files in .tekton/"
+    echo "Expected files matching: rhcl-*-rhcl-operator-push.yaml and rhcl-*-rhcl-operator-pull-request.yaml"
+    exit 1
+  fi
 
-echo "  - Found push pipeline: $PUSH_PIPELINE"
-echo "  - Found PR pipeline: $PR_PIPELINE"
+  echo "  - Found push pipeline: $PUSH_PIPELINE"
+  echo "  - Found PR pipeline: $PR_PIPELINE"
 
-# Detect current KUADRANT_VERSION from pipeline files (may still be named RHCL_VERSION)
-if grep -q 'KUADRANT_VERSION=' "$PUSH_PIPELINE"; then
-  CURRENT_KUADRANT_VERSION=$(grep -m1 'KUADRANT_VERSION=' "$PUSH_PIPELINE" | sed 's/.*KUADRANT_VERSION=\(.*\)/\1/')
-  OLD_VAR_NAME="KUADRANT_VERSION"
-elif grep -q 'RHCL_VERSION=' "$PUSH_PIPELINE"; then
-  CURRENT_KUADRANT_VERSION=$(grep -m1 'RHCL_VERSION=' "$PUSH_PIPELINE" | sed 's/.*RHCL_VERSION=\(.*\)/\1/')
-  OLD_VAR_NAME="RHCL_VERSION"
+  # Detect current KUADRANT_VERSION from pipeline files (may still be named RHCL_VERSION)
+  if grep -q 'KUADRANT_VERSION=' "$PUSH_PIPELINE"; then
+    CURRENT_KUADRANT_VERSION=$(grep -m1 'KUADRANT_VERSION=' "$PUSH_PIPELINE" | sed 's/.*KUADRANT_VERSION=\(.*\)/\1/')
+    OLD_VAR_NAME="KUADRANT_VERSION"
+  elif grep -q 'RHCL_VERSION=' "$PUSH_PIPELINE"; then
+    CURRENT_KUADRANT_VERSION=$(grep -m1 'RHCL_VERSION=' "$PUSH_PIPELINE" | sed 's/.*RHCL_VERSION=\(.*\)/\1/')
+    OLD_VAR_NAME="RHCL_VERSION"
+  else
+    echo "Error: Could not find KUADRANT_VERSION or RHCL_VERSION in $PUSH_PIPELINE"
+    exit 1
+  fi
+
+  echo "  - Current ${OLD_VAR_NAME}: $CURRENT_KUADRANT_VERSION"
+  echo "  - Updating to KUADRANT_VERSION=$KUADRANT_VERSION"
+
+  # Update to KUADRANT_VERSION in both pipeline files
+  sed -i "s/${OLD_VAR_NAME}=$CURRENT_KUADRANT_VERSION/KUADRANT_VERSION=$KUADRANT_VERSION/g" "$PUSH_PIPELINE"
+  sed -i "s/${OLD_VAR_NAME}=$CURRENT_KUADRANT_VERSION/KUADRANT_VERSION=$KUADRANT_VERSION/g" "$PR_PIPELINE"
+  echo ""
 else
-  echo "Error: Could not find KUADRANT_VERSION or RHCL_VERSION in $PUSH_PIPELINE"
-  exit 1
+  echo "Skipping Kuadrant version update (not provided)"
+  echo ""
 fi
-
-echo "  - Current ${OLD_VAR_NAME}: $CURRENT_KUADRANT_VERSION"
-echo "  - Updating to KUADRANT_VERSION=$KUADRANT_VERSION"
-
-# Update to KUADRANT_VERSION in both pipeline files
-sed -i "s/${OLD_VAR_NAME}=$CURRENT_KUADRANT_VERSION/KUADRANT_VERSION=$KUADRANT_VERSION/g" "$PUSH_PIPELINE"
-sed -i "s/${OLD_VAR_NAME}=$CURRENT_KUADRANT_VERSION/KUADRANT_VERSION=$KUADRANT_VERSION/g" "$PR_PIPELINE"
-echo ""
 
 echo "========================================"
 echo "✅ Version bump complete!"
@@ -116,8 +127,10 @@ echo "  - Containerfile.rhcl-operator-bundle"
 echo "  - Containerfile.rhcl-operator-bundle-dev"
 echo "  - Containerfile.rhcl-operator-bundle-stage"
 echo "  - bundle-generation/rhcl-operator.yaml"
-echo "  - $PUSH_PIPELINE"
-echo "  - $PR_PIPELINE"
+if [ -n "$KUADRANT_VERSION" ]; then
+  echo "  - $PUSH_PIPELINE"
+  echo "  - $PR_PIPELINE"
+fi
 echo ""
 echo "Next steps:"
 echo "  1. Review changes: git diff"

--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -e
+
+# Script to bump RHCL and Kuadrant versions
+# Usage: ./bump-version.sh <rhcl-version> [kuadrant-version]
+#   rhcl-version: Required. New RHCL version (e.g., 1.3.4)
+#   kuadrant-version: Optional. Upstream Kuadrant version (e.g., 0.10.0). Defaults to rhcl-version if not provided.
+
+RHCL_VERSION="$1"
+KUADRANT_VERSION="${2:-$1}"  # Default to RHCL version if not provided
+
+# Validation
+if [ -z "$RHCL_VERSION" ]; then
+  echo "Error: RHCL version is required"
+  echo "Usage: $0 <rhcl-version> [kuadrant-version]"
+  exit 1
+fi
+
+if ! echo "$RHCL_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Error: RHCL version must be in X.Y.Z format (e.g., 1.3.4)"
+  exit 1
+fi
+
+if ! echo "$KUADRANT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Error: Kuadrant version must be in X.Y.Z format (e.g., 0.10.0)"
+  exit 1
+fi
+
+# Detect current RHCL version from bundle-generation/rhcl-operator.yaml
+CURRENT_RHCL_VERSION=$(grep '^  version:' bundle-generation/rhcl-operator.yaml | sed 's/.*"\(.*\)".*/\1/')
+
+if [ -z "$CURRENT_RHCL_VERSION" ]; then
+  echo "Error: Could not detect current RHCL version from bundle-generation/rhcl-operator.yaml"
+  exit 1
+fi
+
+echo "========================================"
+echo "RHCL Version Bump"
+echo "========================================"
+echo "Current RHCL version: $CURRENT_RHCL_VERSION"
+echo "New RHCL version: $RHCL_VERSION"
+echo "Kuadrant version: $KUADRANT_VERSION"
+echo "========================================"
+echo ""
+
+# Step 1: Update version labels in bundle Containerfiles
+echo "Updating version labels in Containerfiles..."
+for file in Containerfile.rhcl-operator-bundle Containerfile.rhcl-operator-bundle-dev Containerfile.rhcl-operator-bundle-stage; do
+  echo "  - $file (version)"
+  sed -i "s/version=\"$CURRENT_RHCL_VERSION\"/version=\"$RHCL_VERSION\"/g" "$file"
+done
+echo ""
+
+# Step 2: Update release labels in all Containerfiles
+echo "Updating release labels in Containerfiles..."
+for file in Containerfile.rhcl-operator Containerfile.rhcl-operator-bundle Containerfile.rhcl-operator-bundle-dev Containerfile.rhcl-operator-bundle-stage; do
+  # Check if file has a release label before reporting
+  if grep -q "release=" "$file"; then
+    echo "  - $file (release)"
+    sed -i "s/release=\"$CURRENT_RHCL_VERSION\"/release=\"$RHCL_VERSION\"/g" "$file"
+  fi
+done
+echo ""
+
+# Step 3: Update version in bundle-generation/rhcl-operator.yaml
+echo "Updating bundle-generation/rhcl-operator.yaml..."
+echo "  - CSV name: rhcl-operator.v$CURRENT_RHCL_VERSION → rhcl-operator.v$RHCL_VERSION"
+echo "  - CSV version: \"$CURRENT_RHCL_VERSION\" → \"$RHCL_VERSION\""
+sed -i "s/rhcl-operator\.v$CURRENT_RHCL_VERSION/rhcl-operator.v$RHCL_VERSION/g" bundle-generation/rhcl-operator.yaml
+sed -i "s/version: \"$CURRENT_RHCL_VERSION\"/version: \"$RHCL_VERSION\"/g" bundle-generation/rhcl-operator.yaml
+echo ""
+
+# Step 4: Update KUADRANT_VERSION in Tekton pipelines
+echo "Updating Tekton pipelines..."
+
+# Find the operator pipeline files (branch-agnostic)
+PUSH_PIPELINE=$(find .tekton -name 'rhcl-*-rhcl-operator-push.yaml' | head -n1)
+PR_PIPELINE=$(find .tekton -name 'rhcl-*-rhcl-operator-pull-request.yaml' | head -n1)
+
+if [ -z "$PUSH_PIPELINE" ] || [ -z "$PR_PIPELINE" ]; then
+  echo "Error: Could not find operator pipeline files in .tekton/"
+  echo "Expected files matching: rhcl-*-rhcl-operator-push.yaml and rhcl-*-rhcl-operator-pull-request.yaml"
+  exit 1
+fi
+
+echo "  - Found push pipeline: $PUSH_PIPELINE"
+echo "  - Found PR pipeline: $PR_PIPELINE"
+
+# Detect current KUADRANT_VERSION from pipeline files (may still be named RHCL_VERSION)
+if grep -q 'KUADRANT_VERSION=' "$PUSH_PIPELINE"; then
+  CURRENT_KUADRANT_VERSION=$(grep -m1 'KUADRANT_VERSION=' "$PUSH_PIPELINE" | sed 's/.*KUADRANT_VERSION=\(.*\)/\1/')
+  OLD_VAR_NAME="KUADRANT_VERSION"
+elif grep -q 'RHCL_VERSION=' "$PUSH_PIPELINE"; then
+  CURRENT_KUADRANT_VERSION=$(grep -m1 'RHCL_VERSION=' "$PUSH_PIPELINE" | sed 's/.*RHCL_VERSION=\(.*\)/\1/')
+  OLD_VAR_NAME="RHCL_VERSION"
+else
+  echo "Error: Could not find KUADRANT_VERSION or RHCL_VERSION in $PUSH_PIPELINE"
+  exit 1
+fi
+
+echo "  - Current ${OLD_VAR_NAME}: $CURRENT_KUADRANT_VERSION"
+echo "  - Updating to KUADRANT_VERSION=$KUADRANT_VERSION"
+
+# Update to KUADRANT_VERSION in both pipeline files
+sed -i "s/${OLD_VAR_NAME}=$CURRENT_KUADRANT_VERSION/KUADRANT_VERSION=$KUADRANT_VERSION/g" "$PUSH_PIPELINE"
+sed -i "s/${OLD_VAR_NAME}=$CURRENT_KUADRANT_VERSION/KUADRANT_VERSION=$KUADRANT_VERSION/g" "$PR_PIPELINE"
+echo ""
+
+echo "========================================"
+echo "✅ Version bump complete!"
+echo "========================================"
+echo ""
+echo "Files updated:"
+echo "  - Containerfile.rhcl-operator (if release label exists)"
+echo "  - Containerfile.rhcl-operator-bundle"
+echo "  - Containerfile.rhcl-operator-bundle-dev"
+echo "  - Containerfile.rhcl-operator-bundle-stage"
+echo "  - bundle-generation/rhcl-operator.yaml"
+echo "  - $PUSH_PIPELINE"
+echo "  - $PR_PIPELINE"
+echo ""
+echo "Next steps:"
+echo "  1. Review changes: git diff"
+echo "  2. Commit changes: git commit -am 'Prepare RHCL $RHCL_VERSION release'"
+echo "  3. Create PR: gh pr create --title 'Prepare RHCL $RHCL_VERSION release'"

--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -1,0 +1,121 @@
+name: Patch Release Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New RHCL version (e.g., 1.3.4)'
+        required: true
+        type: string
+      kuadrant_version:
+        description: 'Upstream Kuadrant version (e.g., 0.10.0) - defaults to RHCL version if not provided'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Detect current version
+        id: detect
+        run: |
+          CURRENT_VERSION=$(grep '^  version:' bundle-generation/rhcl-operator.yaml | sed 's/.*"\(.*\)".*/\1/')
+          echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Bump versions
+        id: bump
+        run: |
+          chmod +x .github/scripts/bump-version.sh
+          if [ -n "${{ inputs.kuadrant_version }}" ]; then
+            .github/scripts/bump-version.sh "${{ inputs.version }}" "${{ inputs.kuadrant_version }}"
+          else
+            .github/scripts/bump-version.sh "${{ inputs.version }}"
+          fi
+
+          # Capture pipeline file paths for later use
+          PUSH_PIPELINE=$(find .tekton -name 'rhcl-*-rhcl-operator-push.yaml' | head -n1)
+          PR_PIPELINE=$(find .tekton -name 'rhcl-*-rhcl-operator-pull-request.yaml' | head -n1)
+          echo "push_pipeline=$PUSH_PIPELINE" >> $GITHUB_OUTPUT
+          echo "pr_pipeline=$PR_PIPELINE" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            Prepare RHCL ${{ inputs.version }} release
+
+            Update RHCL version from ${{ steps.detect.outputs.current }} to ${{ inputs.version }}
+            Update Kuadrant version to ${{ inputs.kuadrant_version != '' && inputs.kuadrant_version || inputs.version }}
+
+            Files updated:
+            - Containerfile.rhcl-operator (if release label exists)
+            - Containerfile.rhcl-operator-bundle
+            - Containerfile.rhcl-operator-bundle-dev
+            - Containerfile.rhcl-operator-bundle-stage
+            - bundle-generation/rhcl-operator.yaml
+            - ${{ steps.bump.outputs.push_pipeline }}
+            - ${{ steps.bump.outputs.pr_pipeline }}
+          branch: prep-${{ inputs.version }}
+          delete-branch: true
+          title: Prepare RHCL ${{ inputs.version }} release
+          body: |
+            ## Version Bump
+
+            - **RHCL version**: ${{ steps.detect.outputs.current }} → ${{ inputs.version }}
+            - **Kuadrant version**: ${{ inputs.kuadrant_version != '' && inputs.kuadrant_version || inputs.version }}${{ inputs.kuadrant_version == '' && ' (defaulted to RHCL version)' || '' }}
+
+            This PR prepares the RHCL ${{ inputs.version }} patch release by updating version strings across the build infrastructure.
+
+            ### Files Updated
+
+            - **Containerfile.rhcl-operator** (if release label exists)
+              - Updated `release` label
+            - **Containerfile.rhcl-operator-bundle** (lines 20, 31)
+              - Updated `version` and `release` labels
+            - **Containerfile.rhcl-operator-bundle-dev** (lines 20, 31)
+              - Updated `version` and `release` labels
+            - **Containerfile.rhcl-operator-bundle-stage** (lines 20, 31)
+              - Updated `version` and `release` labels
+            - **bundle-generation/rhcl-operator.yaml** (lines 7-8)
+              - Updated `csv.name`: `rhcl-operator.v${{ steps.detect.outputs.current }}` → `rhcl-operator.v${{ inputs.version }}`
+              - Updated `csv.version`: `"${{ steps.detect.outputs.current }}"` → `"${{ inputs.version }}"`
+            - **${{ steps.bump.outputs.push_pipeline }}**
+              - Updated `KUADRANT_VERSION` build arg
+            - **${{ steps.bump.outputs.pr_pipeline }}**
+              - Updated `KUADRANT_VERSION` build arg
+
+            ### Next Steps
+
+            - [ ] Review version changes
+            - [ ] Verify bundle generation still works (`make bundle`)
+            - [ ] Merge to trigger Konflux builds
+
+            ---
+
+            *This PR was automatically created by the [patch-release workflow](.github/workflows/patch-release.yml).*
+          labels: |
+            release
+            automated
+          reviewers: |
+            ${{ github.actor }}
+
+      - name: Summary
+        run: |
+          echo "✅ Version bump PR created"
+          echo "RHCL version: ${{ steps.detect.outputs.current }} → ${{ inputs.version }}"
+          if [ -n "${{ inputs.kuadrant_version }}" ]; then
+            echo "Kuadrant version: ${{ inputs.kuadrant_version }}"
+          else
+            echo "Kuadrant version: ${{ inputs.version }} (defaulted to RHCL version)"
+          fi
+          echo "Branch: prep-${{ inputs.version }}"

--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       kuadrant_version:
-        description: 'Upstream Kuadrant version (e.g., 0.10.0) - defaults to RHCL version if not provided'
+        description: 'Upstream Kuadrant version (e.g., 1.4.0) - leave empty to keep current version unchanged'
         required: false
         type: string
 
@@ -54,25 +54,25 @@ jobs:
           commit-message: |
             Prepare RHCL ${{ inputs.version }} release
 
-            Update RHCL version from ${{ steps.detect.outputs.current }} to ${{ inputs.version }}
-            Update Kuadrant version to ${{ inputs.kuadrant_version != '' && inputs.kuadrant_version || inputs.version }}
+            Update RHCL version from ${{ steps.detect.outputs.current }} to ${{ inputs.version }}${{ inputs.kuadrant_version != '' && format('
+            Update Kuadrant version to {0}', inputs.kuadrant_version) || '' }}
 
             Files updated:
             - Containerfile.rhcl-operator (if release label exists)
             - Containerfile.rhcl-operator-bundle
             - Containerfile.rhcl-operator-bundle-dev
             - Containerfile.rhcl-operator-bundle-stage
-            - bundle-generation/rhcl-operator.yaml
-            - ${{ steps.bump.outputs.push_pipeline }}
-            - ${{ steps.bump.outputs.pr_pipeline }}
+            - bundle-generation/rhcl-operator.yaml${{ inputs.kuadrant_version != '' && format('
+            - {0}
+            - {1}', steps.bump.outputs.push_pipeline, steps.bump.outputs.pr_pipeline) || '' }}
           branch: prep-${{ inputs.version }}
           delete-branch: true
           title: Prepare RHCL ${{ inputs.version }} release
           body: |
             ## Version Bump
 
-            - **RHCL version**: ${{ steps.detect.outputs.current }} → ${{ inputs.version }}
-            - **Kuadrant version**: ${{ inputs.kuadrant_version != '' && inputs.kuadrant_version || inputs.version }}${{ inputs.kuadrant_version == '' && ' (defaulted to RHCL version)' || '' }}
+            - **RHCL version**: ${{ steps.detect.outputs.current }} → ${{ inputs.version }}${{ inputs.kuadrant_version != '' && format('
+            - **Kuadrant version**: {0}', inputs.kuadrant_version) || '' }}
 
             This PR prepares the RHCL ${{ inputs.version }} patch release by updating version strings across the build infrastructure.
 
@@ -88,11 +88,11 @@ jobs:
               - Updated `version` and `release` labels
             - **bundle-generation/rhcl-operator.yaml** (lines 7-8)
               - Updated `csv.name`: `rhcl-operator.v${{ steps.detect.outputs.current }}` → `rhcl-operator.v${{ inputs.version }}`
-              - Updated `csv.version`: `"${{ steps.detect.outputs.current }}"` → `"${{ inputs.version }}"`
-            - **${{ steps.bump.outputs.push_pipeline }}**
-              - Updated `KUADRANT_VERSION` build arg
-            - **${{ steps.bump.outputs.pr_pipeline }}**
-              - Updated `KUADRANT_VERSION` build arg
+              - Updated `csv.version`: `"${{ steps.detect.outputs.current }}"` → `"${{ inputs.version }}"`${{ inputs.kuadrant_version != '' && format('
+            - **{0}**
+              - Updated `KUADRANT_VERSION` build arg to `{1}`
+            - **{2}**
+              - Updated `KUADRANT_VERSION` build arg to `{1}`', steps.bump.outputs.push_pipeline, inputs.kuadrant_version, steps.bump.outputs.pr_pipeline) || '' }}
 
             ### Next Steps
 
@@ -116,6 +116,6 @@ jobs:
           if [ -n "${{ inputs.kuadrant_version }}" ]; then
             echo "Kuadrant version: ${{ inputs.kuadrant_version }}"
           else
-            echo "Kuadrant version: ${{ inputs.version }} (defaulted to RHCL version)"
+            echo "Kuadrant version: (unchanged)"
           fi
           echo "Branch: prep-${{ inputs.version }}"

--- a/.tekton/rhcl-1-3-rhcl-operator-pull-request.yaml
+++ b/.tekton/rhcl-1-3-rhcl-operator-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
     value: '[{"type": "rpm", "path": "."}, {"type": "gomod", "path": "kuadrant-operator/"}]'
   - name: build-args
     value:
-    - RHCL_VERSION=1.3.0
+    - KUADRANT_VERSION=1.3.0
     - GIT_SHA={{revision}}
     - DIRTY=false
   pipelineRef:

--- a/.tekton/rhcl-1-3-rhcl-operator-push.yaml
+++ b/.tekton/rhcl-1-3-rhcl-operator-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: '[{"type": "rpm", "path": "."}, {"type": "gomod", "path": "kuadrant-operator/"}]'
   - name: build-args
     value:
-    - RHCL_VERSION=1.3.0
+    - KUADRANT_VERSION=1.3.0
     - GIT_SHA={{revision}}
     - DIRTY=false
   pipelineRef:

--- a/Containerfile.rhcl-operator
+++ b/Containerfile.rhcl-operator
@@ -23,17 +23,17 @@ ARG TARGETARCH
 # Build arguments aligned with upstream
 ARG GIT_SHA
 ARG DIRTY
-ARG RHCL_VERSION
+ARG KUADRANT_VERSION
 ARG WITH_EXTENSIONS=true
 
 ENV GIT_SHA=${GIT_SHA:-unknown}
 ENV DIRTY=${DIRTY:-unknown}
-ENV RHCL_VERSION=${RHCL_VERSION:-unknown}
+ENV KUADRANT_VERSION=${KUADRANT_VERSION:-unknown}
 
 # Build RHCL Operator
-RUN echo "Building with RHCL_VERSION=${RHCL_VERSION}, GIT_SHA=${GIT_SHA}, DIRTY=${DIRTY}" && \
+RUN echo "Building with KUADRANT_VERSION=${KUADRANT_VERSION}, GIT_SHA=${GIT_SHA}, DIRTY=${DIRTY}" && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a \
-    -ldflags "-X main.version=${RHCL_VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" \
+    -ldflags "-X main.version=${KUADRANT_VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" \
     -o manager cmd/main.go
 
 # Conditionally build extensions
@@ -51,9 +51,9 @@ RUN if [ "$WITH_EXTENSIONS" = "true" ]; then \
     fi
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest
-ARG RHCL_VERSION
-ENV RHCL_VERSION=${RHCL_VERSION:-unknown}
-LABEL version="${RHCL_VERSION}" \
+ARG KUADRANT_VERSION
+ENV KUADRANT_VERSION=${KUADRANT_VERSION:-unknown}
+LABEL version="${KUADRANT_VERSION}" \
       summary="Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments" \
       name="rhcl-1/rhcl-rhel9-operator" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \


### PR DESCRIPTION
---
  Add GitHub Action for Automated Patch Release Version Bumps

  Summary

  This PR introduces automation for the patch release version bump process, making it easier and less error-prone to prepare release PRs.

  What's New

  1. GitHub Action Workflow (.github/workflows/patch-release.yml)

  A new workflow_dispatch action that automates the entire version bump process:

  Inputs:
  - version (required): New RHCL version (e.g., 1.3.4)
  - kuadrant_version (optional): Upstream Kuadrant version (e.g., 0.10.0)
  What it does:
  1. Validates version format (X.Y.Z)
  2. Runs the version bump script
  3. Creates a PR on a prep-{version} branch with all changes
