### PR TITLE
Update kuadrant-operator submodule to track release-1.4 rather than t…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "kuadrant-operator"]
 	path = kuadrant-operator
 	url = https://github.com/kuadrant/kuadrant-operator
-	branch = release-v1.3
+	branch = release-1.4

--- a/.tekton/rhcl-1-3-rhcl-operator-pull-request.yaml
+++ b/.tekton/rhcl-1-3-rhcl-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.3" && ( "kuadrant-operator/*".pathChanged() || "Containerfile.rhcl-operator".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/".pathChanged() || ".tekton/rhcl-1-3-rhcl-operator-pull-request.yaml".pathChanged() || ".tekton/multi-arch-build-pipeline.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.3" && ( "kuadrant-operator".pathChanged() || "Containerfile.rhcl-operator".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/".pathChanged() || ".tekton/rhcl-1-3-rhcl-operator-pull-request.yaml".pathChanged() || ".tekton/multi-arch-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhcl-1-3-rhcl-operator

--- a/.tekton/rhcl-1-3-rhcl-operator-push.yaml
+++ b/.tekton/rhcl-1-3-rhcl-operator-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.3" && ( "kuadrant-operator/*".pathChanged() || "Containerfile.rhcl-operator".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-3-rhcl-operator-push.yaml".pathChanged() || ".tekton/multi-arch-build-pipeline.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.3" && ( "kuadrant-operator".pathChanged() || "Containerfile.rhcl-operator".pathChanged() || "rpms.lock.yaml".pathChanged() || "config/*".pathChanged() || ".tekton/rhcl-1-3-rhcl-operator-push.yaml".pathChanged() || ".tekton/multi-arch-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhcl-1-3-rhcl-operator


### PR DESCRIPTION
…he older branch format

Previously the branch in .gitmodules was not used and submodules were updated manually, now with the new consistent branch/release structure we can leave the submodule updating to the automation, which will automatically update to the latest commit on the release-1.4 branch