### PR TITLE
Extract wasm binary at build time

### DIFF
--- a/.github/workflows/generate-bundle.yml
+++ b/.github/workflows/generate-bundle.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Check if the generated output differs from what's already committed
         id: changes
         run: |
-          if git diff --quiet ./bundle ./bundle-dev ./bundle-stage && \
+          if git diff --quiet ./bundle ./bundle-dev ./bundle-stage ./Containerfile.rhcl-operator && \
              [ -z "$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle ./bundle-dev ./bundle-stage)" ]; then
             echo "changes=false" >> $GITHUB_OUTPUT
           else
@@ -51,7 +51,8 @@ jobs:
         if: steps.changes.outputs.changes == 'true'
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: Generate Bundles after change to image-pullspecs.yaml or rhcl-operator.yaml
+          commit_message: Generate Bundles and update Containerfile after change to image-pullspecs or rhcl-operator.yaml
+          file_pattern: 'bundle/ bundle-dev/ bundle-stage/ Containerfile.rhcl-operator'
 
       - name: Validate bundles
         run: make validate-bundle

--- a/Containerfile.rhcl-operator
+++ b/Containerfile.rhcl-operator
@@ -1,3 +1,10 @@
+# Extract the wasm-shim binary (platform-independent) from the OCI image
+# This default value is automatically updated by bundle-generation/generate-bundle.sh
+# which reads the current image from bundle-generation/image-pullspecs/wasm-shim.yaml
+# The WASM_SHIM_IMAGE can be overridden via build args if needed
+ARG WASM_SHIM_IMAGE=quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-wasm-shim@sha256:4b8cd7dea4d9cd3c7170af872c229e206155691e7dbb4a90c64699ccecc7ccbb
+FROM ${WASM_SHIM_IMAGE} AS wasm-shim
+
 # Build the manager binary
 FROM registry.redhat.io/ubi9/go-toolset:latest AS builder
 
@@ -76,6 +83,7 @@ USER root
 COPY --from=builder licenses/LICENSE /licenses/LICENSE
 COPY --from=builder /workspace/${OPERATOR_BINARY_NAME} /
 COPY --from=builder /workspace/extensions /extensions
+COPY --from=wasm-shim /plugin.wasm /wasm/plugin.wasm
 RUN chown ${USER_UID} /${OPERATOR_BINARY_NAME}
 
 # # TODO: Install licenses

--- a/Containerfile.rhcl-operator
+++ b/Containerfile.rhcl-operator
@@ -2,7 +2,7 @@
 # This default value is automatically updated by bundle-generation/generate-bundle.sh
 # which reads the current image from bundle-generation/image-pullspecs/wasm-shim.yaml
 # The WASM_SHIM_IMAGE can be overridden via build args if needed
-ARG WASM_SHIM_IMAGE=quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-wasm-shim@sha256:4b8cd7dea4d9cd3c7170af872c229e206155691e7dbb4a90c64699ccecc7ccbb
+ARG WASM_SHIM_IMAGE=quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-wasm-shim@sha256:c2b1cfcbd4aee9ccb517ac35eb2aebb29c82d01afcb216e94503ed9bd6fafbe3
 FROM ${WASM_SHIM_IMAGE} AS wasm-shim
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@
 bundle: ## Generate all bundle variants (prod, dev, stage) using YQ
 	@./bundle-generation/generate-bundle.sh
 
-validate-bundle: ## Validate that committed bundles match what would be generated.
+validate-bundle: ## Validate that committed bundles and Containerfile match what would be generated.
 	@./bundle-generation/generate-bundle.sh
-	@if git diff --quiet ./bundle ./bundle-dev ./bundle-stage && \
+	@if git diff --quiet ./bundle ./bundle-dev ./bundle-stage ./Containerfile.rhcl-operator && \
 		[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle ./bundle-dev ./bundle-stage)" ]; then \
-		echo "Bundles are valid and up to date"; \
+		echo "Bundles and Containerfile are valid and up to date"; \
 	else \
-		echo "ERROR: Bundles are out of sync. Run 'make bundle' and commit the changes."; \
-		git diff --stat ./bundle ./bundle-dev ./bundle-stage; \
+		echo "ERROR: Bundles or Containerfile are out of sync. Run 'make bundle' and commit the changes."; \
+		git diff --stat ./bundle ./bundle-dev ./bundle-stage ./Containerfile.rhcl-operator; \
 		exit 1; \
 	fi

--- a/bundle-generation/generate-bundle.sh
+++ b/bundle-generation/generate-bundle.sh
@@ -259,3 +259,27 @@ echo "  - bundle/       (production)"
 echo "  - bundle-dev/   (development)"
 echo "  - bundle-stage/ (staging)"
 echo ""
+
+# Update Containerfile.rhcl-operator with current wasm-shim image
+echo "========================================"
+echo "Updating Containerfile.rhcl-operator"
+echo "========================================"
+CONTAINERFILE="${PROJECT_ROOT}/Containerfile.rhcl-operator"
+
+if [[ ! -f "$CONTAINERFILE" ]]; then
+    echo "Warning: Containerfile not found at $CONTAINERFILE, skipping update"
+else
+    echo "Updating WASM_SHIM_IMAGE default to: ${WASM_SHIM_IMAGE}"
+
+    # Update the ARG WASM_SHIM_IMAGE line with the current image
+    # This uses sed to replace the line that starts with "ARG WASM_SHIM_IMAGE="
+    if grep -q "^ARG WASM_SHIM_IMAGE=" "$CONTAINERFILE"; then
+        # Use a temporary file for atomic update
+        sed "s|^ARG WASM_SHIM_IMAGE=.*|ARG WASM_SHIM_IMAGE=${WASM_SHIM_IMAGE}|" "$CONTAINERFILE" > "${CONTAINERFILE}.tmp"
+        mv "${CONTAINERFILE}.tmp" "$CONTAINERFILE"
+        echo "✓ Updated WASM_SHIM_IMAGE in Containerfile"
+    else
+        echo "Warning: Could not find 'ARG WASM_SHIM_IMAGE=' in Containerfile"
+    fi
+fi
+echo ""


### PR DESCRIPTION
Downstream equivalent to https://github.com/Kuadrant/kuadrant-operator/pull/1953/changes#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557

Just the wasm binary extraction is needed, operator logic will be taken from upstream