### PR TITLE
Setup for rhcl-operator-1.3.5 bundle

### DIFF
--- a/Containerfile.rhcl-operator-bundle
+++ b/Containerfile.rhcl-operator-bundle
@@ -17,7 +17,7 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 
-LABEL version="1.3.4" \
+LABEL version="1.3.5" \
       summary="Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments" \
       name="rhcl-1/rhcl-operator-bundle" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \
@@ -28,7 +28,7 @@ LABEL version="1.3.4" \
       io.openshift.tags="api" \
       url="redhat.com" \
       distribution-scope="public" \
-      release="1.3.4" \
+      release="1.3.5" \
       url="" \
       com.redhat.component="Red Hat Connectivity Link Operator Bundle" \
       vendor="Red Hat, Inc."

--- a/Containerfile.rhcl-operator-bundle-dev
+++ b/Containerfile.rhcl-operator-bundle-dev
@@ -17,7 +17,7 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 
-LABEL version="1.3.4" \
+LABEL version="1.3.5" \
       summary="Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments" \
       name="rhcl-1/rhcl-operator-bundle" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \
@@ -28,7 +28,7 @@ LABEL version="1.3.4" \
       io.openshift.tags="api" \
       url="redhat.com" \
       distribution-scope="public" \
-      release="1.3.4" \
+      release="1.3.5" \
       url="" \
       com.redhat.component="Red Hat Connectivity Link Operator Bundle" \
       vendor="Red Hat, Inc."

--- a/Containerfile.rhcl-operator-bundle-stage
+++ b/Containerfile.rhcl-operator-bundle-stage
@@ -17,7 +17,7 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 
-LABEL version="1.3.4" \
+LABEL version="1.3.5" \
       summary="Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments" \
       name="rhcl-1/rhcl-operator-bundle" \
       cpe="cpe:/a:redhat:connectivity_link:1::el9" \
@@ -28,7 +28,7 @@ LABEL version="1.3.4" \
       io.openshift.tags="api" \
       url="redhat.com" \
       distribution-scope="public" \
-      release="1.3.4" \
+      release="1.3.5" \
       url="" \
       com.redhat.component="Red Hat Connectivity Link Operator Bundle" \
       vendor="Red Hat, Inc."

--- a/bundle-dev/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle-dev/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-rhcl-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
-    createdAt: "2026-05-22T10:26:17Z"
+    createdAt: "2026-06-22T17:00:01Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -242,7 +242,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-  name: rhcl-operator.v1.3.4
+  name: rhcl-operator.v1.3.5
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -918,4 +918,4 @@ spec:
       name: console-plugin-latest
     - image: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-3-rhcl-console-plugin-0-1-5@sha256:be66268555a8d7043ceb6099ff02306e5a5455201dd46ff69c9c2eca9b93f760
       name: console-plugin-pf5
-  version: 1.3.4
+  version: 1.3.5

--- a/bundle-dev/metadata/dependencies.yaml
+++ b/bundle-dev/metadata/dependencies.yaml
@@ -2,7 +2,7 @@ dependencies:
   - type: olm.package
     value:
       packageName: authorino-operator
-      version: "1.3.1"
+      version: "1.3.2"
   - type: olm.package
     value:
       packageName: limitador-operator

--- a/bundle-generation/rhcl-operator.yaml
+++ b/bundle-generation/rhcl-operator.yaml
@@ -4,8 +4,8 @@
 
 # CSV metadata
 csv:
-  name: rhcl-operator.v1.3.4
-  version: "1.3.4"
+  name: rhcl-operator.v1.3.5
+  version: "1.3.5"
   displayName: Red Hat Connectivity Link
   description: "Red Hat Connectivity Link enables you to secure, protect, and connect your APIs and applications in multicluster, multicloud, and hybrid cloud environments."
   icon:
@@ -83,6 +83,6 @@ outputDirs:
 
 # OLM package dependencies (downstream versions differ from upstream)
 dependencies:
-  authorino-operator: "1.3.1"
+  authorino-operator: "1.3.2"
   limitador-operator: "1.3.1"
   dns-operator: "1.3.1"

--- a/bundle-stage/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle-stage/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: registry.stage.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
-    createdAt: "2026-05-22T10:26:17Z"
+    createdAt: "2026-06-22T17:00:01Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -242,7 +242,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-  name: rhcl-operator.v1.3.4
+  name: rhcl-operator.v1.3.5
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -918,4 +918,4 @@ spec:
       name: console-plugin-latest
     - image: registry.stage.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:be66268555a8d7043ceb6099ff02306e5a5455201dd46ff69c9c2eca9b93f760
       name: console-plugin-pf5
-  version: 1.3.4
+  version: 1.3.5

--- a/bundle-stage/metadata/dependencies.yaml
+++ b/bundle-stage/metadata/dependencies.yaml
@@ -2,7 +2,7 @@ dependencies:
   - type: olm.package
     value:
       packageName: authorino-operator
-      version: "1.3.1"
+      version: "1.3.2"
   - type: olm.package
     value:
       packageName: limitador-operator

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: registry.redhat.io/rhcl-1/rhcl-rhel9-operator@sha256:abdf3e87fb3d6a60bd0da5fed33916cc064b376fc1a6514d2621d9763dcba151
-    createdAt: "2026-05-22T10:26:17Z"
+    createdAt: "2026-06-22T17:00:01Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -242,7 +242,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     operators.openshift.io/valid-subscription: '["Red Hat Connectivity Link"]'
-  name: rhcl-operator.v1.3.4
+  name: rhcl-operator.v1.3.5
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -918,4 +918,4 @@ spec:
       name: console-plugin-latest
     - image: registry.redhat.io/rhcl-1/rhcl-console-plugin-rhel9@sha256:be66268555a8d7043ceb6099ff02306e5a5455201dd46ff69c9c2eca9b93f760
       name: console-plugin-pf5
-  version: 1.3.4
+  version: 1.3.5

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -2,7 +2,7 @@ dependencies:
   - type: olm.package
     value:
       packageName: authorino-operator
-      version: "1.3.1"
+      version: "1.3.2"
   - type: olm.package
     value:
       packageName: limitador-operator


### PR DESCRIPTION
No changes to bundle content, just depends on authorino-operator-1.3.2 (0.23.3) instead of 1.3.1 (0.23.2)